### PR TITLE
Fix incorrect safety annotations

### DIFF
--- a/libtls/src/config.rs
+++ b/libtls/src/config.rs
@@ -136,13 +136,17 @@ impl TlsConfig {
     }
 
     /// Wrap a raw C `tls_config` object.
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// This function assumes that the raw pointer is valid, and takes
     /// ownership of the libtls object.
     /// Do not call `tls_free` yourself, since the `drop` destructor will
     /// take care of it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `config` is a null pointer.
     pub unsafe fn from_sys(config: *mut libtls_sys::tls_config) -> Self {
         if config.is_null() {
             panic!(io::Error::last_os_error())

--- a/libtls/src/config.rs
+++ b/libtls/src/config.rs
@@ -135,6 +135,21 @@ impl TlsConfig {
         }
     }
 
+    /// Wrap a raw C `tls_config` object.
+    /// 
+    /// # Safety
+    /// 
+    /// This function assumes that the raw pointer is valid, and takes
+    /// ownership of the libtls object.
+    /// Do not call `tls_free` yourself, since the `drop` destructor will
+    /// take care of it.
+    pub unsafe fn from_sys(config: *mut libtls_sys::tls_config) -> Self {
+        if config.is_null() {
+            panic!(io::Error::last_os_error())
+        }
+        TlsConfig(config)
+    }
+
     /// Add additional files of a public and private key pair.
     ///
     /// The `add_keypair_file` method adds an additional public certificate, and
@@ -998,15 +1013,6 @@ impl error::LastError for TlsConfig {
 
     fn to_error<T>(errstr: String) -> error::Result<T> {
         Err(error::TlsError::ConfigError(errstr))
-    }
-}
-
-impl From<*mut libtls_sys::tls_config> for TlsConfig {
-    fn from(config: *mut libtls_sys::tls_config) -> Self {
-        if config.is_null() {
-            panic!(io::Error::last_os_error())
-        }
-        TlsConfig(config)
     }
 }
 

--- a/libtls/src/tls.rs
+++ b/libtls/src/tls.rs
@@ -166,13 +166,17 @@ impl Tls {
     }
 
     /// Wrap a raw C `tls` object.
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// This function assumes that the raw pointer is valid, and takes
     /// ownership of the libtls object.
     /// Do not call `tls_free` yourself, since the `drop` destructor will
     /// take care of it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `tls` is a null pointer.
     pub unsafe fn from_sys(tls: *mut libtls_sys::tls) -> Self {
         if tls.is_null() {
             panic!(io::Error::last_os_error())
@@ -207,7 +211,7 @@ impl Tls {
                 self,
                 libtls_sys::tls_accept_fds(self.0, &mut cctx, fd_read, fd_write),
             )?;
-            Ok(cctx.into())
+            Ok(Self::from_sys(cctx))
         }
     }
 
@@ -231,7 +235,7 @@ impl Tls {
                 libtls_sys::tls_accept_socket(self.0, &mut cctx, socket),
             )?;
             self.1 = socket;
-            Ok(cctx.into())
+            Ok(Self::from_sys(cctx))
         }
     }
 
@@ -278,7 +282,7 @@ impl Tls {
             self,
             libtls_sys::tls_accept_cbs(self.0, &mut cctx, read_cb, write_cb, cb_arg),
         )?;
-        Ok(cctx.into())
+        Ok(Self::from_sys(cctx))
     }
 
     /// Initiate a new TLS connection.

--- a/libtls/src/tls.rs
+++ b/libtls/src/tls.rs
@@ -165,6 +165,21 @@ impl Tls {
         cvt(self, unsafe { libtls_sys::tls_configure(self.0, config.0) })
     }
 
+    /// Wrap a raw C `tls` object.
+    /// 
+    /// # Safety
+    /// 
+    /// This function assumes that the raw pointer is valid, and takes
+    /// ownership of the libtls object.
+    /// Do not call `tls_free` yourself, since the `drop` destructor will
+    /// take care of it.
+    pub unsafe fn from_sys(tls: *mut libtls_sys::tls) -> Self {
+        if tls.is_null() {
+            panic!(io::Error::last_os_error())
+        }
+        Tls(tls, -1)
+    }
+
     /// Reset the TLS connection.
     ///
     /// A TLS context can be `reset`, allowing for it to be reused.
@@ -883,15 +898,6 @@ impl LastError for Tls {
 
     fn to_error<T>(errstr: String) -> error::Result<T> {
         Err(error::TlsError::CtxError(errstr))
-    }
-}
-
-impl From<*mut libtls_sys::tls> for Tls {
-    fn from(tls: *mut libtls_sys::tls) -> Self {
-        if tls.is_null() {
-            panic!(io::Error::last_os_error())
-        }
-        Tls(tls, -1)
     }
 }
 

--- a/tokio-libtls/src/lib.rs
+++ b/tokio-libtls/src/lib.rs
@@ -368,6 +368,8 @@ mod test {
 
     #[tokio::test]
     async fn test_async_https_connect() {
-        async_https_connect("www.example.com".to_owned()).await.unwrap();
+        async_https_connect("www.example.com".to_owned())
+            .await
+            .unwrap();
     }
 }


### PR DESCRIPTION
The `Tls` and `TlsConfig` functions require, as an invariant, that the wrapped pointer does not dangle. This invariant must be maintained by all available constructors for these objects.

The `From` implementations did not maintain it. They checked for null pointers, but they did not and cannot check for dangling pointers. They were also marked as safe. This allows one to use rust-libtls to invoke undefined behavior in safe code.

    // Safe Rust allows you to construct arbitrary raw pointers.
    let my_raw_ptr = 3 as usize as *mut libtls_sys::tls;
    // Violate the invariant that Tls wraps a valid tls pointer.
    let my_tls_object = Tls::from(my_raw_ptr);
    // Invoke undefined behavior by dereferencing it in tls_reset.
    my_tls_object.reset();